### PR TITLE
Move import to avoid possible ImportError.

### DIFF
--- a/bigquery/client.py
+++ b/bigquery/client.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 from apiclient.discovery import build
 import httplib2
-from oauth2client.client import SignedJwtAssertionCredentials
 
 from bigquery import logger
 
@@ -53,14 +52,18 @@ def _get_bq_service(credentials=None, service_account=None, private_key=None,
 
     if not credentials:
         scope = BIGQUERY_SCOPE_READ_ONLY if readonly else BIGQUERY_SCOPE
-        credentials = SignedJwtAssertionCredentials(
-            service_account, private_key, scope=scope)
+        credentials = _credentials(service_account, private_key, scope=scope)
 
     http = httplib2.Http()
     http = credentials.authorize(http)
     service = build('bigquery', 'v2', http=http)
 
     return service
+
+
+def _credentials():
+    from oauth2client.client import SignedJwtAssertionCredentials
+    return SignedJwtAssertionCredentials
 
 
 class BigQueryClient(object):

--- a/bigquery/tests/test_client.py
+++ b/bigquery/tests/test_client.py
@@ -22,7 +22,7 @@ class TestGetClient(unittest.TestCase):
 
         self.assertRaises(Exception, client.get_client, 'foo', 'bar')
 
-    @mock.patch('bigquery.client.SignedJwtAssertionCredentials')
+    @mock.patch('bigquery.client._credentials')
     @mock.patch('bigquery.client.build')
     def test_initialize_readonly(self, mock_build, mock_cred):
         """Ensure that a BigQueryClient is initialized and returned with
@@ -49,7 +49,7 @@ class TestGetClient(unittest.TestCase):
         self.assertEquals(mock_bq, bq_client.bigquery)
         self.assertEquals(project_id, bq_client.project_id)
 
-    @mock.patch('bigquery.client.SignedJwtAssertionCredentials')
+    @mock.patch('bigquery.client._credentials')
     @mock.patch('bigquery.client.build')
     def test_initialize_read_write(self, mock_build, mock_cred):
         """Ensure that a BigQueryClient is initialized and returned with


### PR DESCRIPTION
When importing `bigquery.client` from within a Flask app, I kept running into a import issue with `SignedJwtAssertionCredentials`. Moving the import to only where it's called fixed the issue.

@tylertreat
