### PR TITLE
Move import to avoid possible ImportError.

### DIFF
--- a/bigquery/client.py
+++ b/bigquery/client.py
@@ -52,7 +52,7 @@ def _get_bq_service(credentials=None, service_account=None, private_key=None,
 
     if not credentials:
         scope = BIGQUERY_SCOPE_READ_ONLY if readonly else BIGQUERY_SCOPE
-        credentials = _credentials(service_account, private_key, scope=scope)
+        credentials = _credentials()(service_account, private_key, scope=scope)
 
     http = httplib2.Http()
     http = credentials.authorize(http)
@@ -62,6 +62,7 @@ def _get_bq_service(credentials=None, service_account=None, private_key=None,
 
 
 def _credentials():
+    """Import and return SignedJwtAssertionCredentials class"""
     from oauth2client.client import SignedJwtAssertionCredentials
     return SignedJwtAssertionCredentials
 

--- a/bigquery/tests/test_client.py
+++ b/bigquery/tests/test_client.py
@@ -24,12 +24,13 @@ class TestGetClient(unittest.TestCase):
 
     @mock.patch('bigquery.client._credentials')
     @mock.patch('bigquery.client.build')
-    def test_initialize_readonly(self, mock_build, mock_cred):
+    def test_initialize_readonly(self, mock_build, mock_return_cred):
         """Ensure that a BigQueryClient is initialized and returned with
         read-only permissions.
         """
         from bigquery.client import BIGQUERY_SCOPE_READ_ONLY
 
+        mock_cred = mock.Mock()
         mock_http = mock.Mock()
         mock_cred.return_value.authorize.return_value = mock_http
         mock_bq = mock.Mock()
@@ -37,11 +38,13 @@ class TestGetClient(unittest.TestCase):
         key = 'key'
         service_account = 'account'
         project_id = 'project'
+        mock_return_cred.return_value = mock_cred
 
         bq_client = client.get_client(
             project_id, service_account=service_account, private_key=key,
             readonly=True)
 
+        mock_return_cred.assert_called_once_with()
         mock_cred.assert_called_once_with(service_account, key,
                                           scope=BIGQUERY_SCOPE_READ_ONLY)
         mock_cred.authorize.assert_called_once()
@@ -51,12 +54,13 @@ class TestGetClient(unittest.TestCase):
 
     @mock.patch('bigquery.client._credentials')
     @mock.patch('bigquery.client.build')
-    def test_initialize_read_write(self, mock_build, mock_cred):
+    def test_initialize_read_write(self, mock_build, mock_return_cred):
         """Ensure that a BigQueryClient is initialized and returned with
         read/write permissions.
         """
         from bigquery.client import BIGQUERY_SCOPE
 
+        mock_cred = mock.Mock()
         mock_http = mock.Mock()
         mock_cred.return_value.authorize.return_value = mock_http
         mock_bq = mock.Mock()
@@ -64,11 +68,13 @@ class TestGetClient(unittest.TestCase):
         key = 'key'
         service_account = 'account'
         project_id = 'project'
+        mock_return_cred.return_value = mock_cred
 
         bq_client = client.get_client(
             project_id, service_account=service_account, private_key=key,
             readonly=False)
 
+        mock_return_cred.assert_called_once_with()
         mock_cred.assert_called_once_with(service_account, key,
                                           scope=BIGQUERY_SCOPE)
         mock_cred.authorize.assert_called_once()


### PR DESCRIPTION
When importing `bigquery.client` from within a Flask app, I kept running into a import issue with `SignedJwtAssertionCredentials`. Moving the import to only where it's called fixed the issue.

I have tested this code manually.

@tylertreat
