### PR TITLE
Raise exception for unfinished queries.

### DIFF
--- a/bigquery/client.py
+++ b/bigquery/client.py
@@ -12,6 +12,10 @@ BIGQUERY_SCOPE = 'https://www.googleapis.com/auth/bigquery'
 BIGQUERY_SCOPE_READ_ONLY = 'https://www.googleapis.com/auth/bigquery.readonly'
 
 
+class UnfinishedQueryException(Exception):
+    pass
+
+
 def get_client(project_id, credentials=None, service_account=None,
                private_key=None, readonly=True):
     """Return a singleton instance of BigQueryClient. Either
@@ -118,7 +122,7 @@ class BigQueryClient(object):
 
         if not query_reply['jobComplete']:
             logger.warning('BigQuery job %s not complete' % job_id)
-            return []
+            raise UnfinishedQueryException()
 
         return query_reply['schema']['fields']
 
@@ -159,7 +163,7 @@ class BigQueryClient(object):
 
         if not query_reply['jobComplete']:
             logger.warning('BigQuery job %s not complete' % job_id)
-            return []
+            raise UnfinishedQueryException()
 
         schema = query_reply['schema']['fields']
         rows = query_reply.get('rows', [])

--- a/bigquery/tests/test_client.py
+++ b/bigquery/tests/test_client.py
@@ -510,9 +510,8 @@ class TestGetQuerySchema(unittest.TestCase):
             'schema': {'fields': 'This is our schema'}
         }
 
-        result_schema = bq.get_query_schema(job_id=123)
-
-        self.assertEquals(result_schema, [])
+        self.assertRaises(client.UnfinishedQueryException, bq.get_query_schema,
+                          job_id=123)
 
 
 @mock.patch('bigquery.client.BigQueryClient._get_query_results')
@@ -568,10 +567,8 @@ class TestGetQueryRows(unittest.TestCase):
             'totalRows': 2
         }
 
-        result_rows = bq.get_query_rows(job_id=123, offset=0, limit=0)
-
-        expected_rows = []
-        self.assertEquals(result_rows, expected_rows)
+        self.assertRaises(client.UnfinishedQueryException, bq.get_query_rows,
+                          job_id=123, offset=0, limit=0)
 
 
 class TestCheckTable(unittest.TestCase):


### PR DESCRIPTION
Raise UnfinishedQueryException if trying to get query results
for an unfinished query.

@tylertreat
