### PR TITLE
Nested schema object in a fields key

### DIFF
--- a/bigquery/client.py
+++ b/bigquery/client.py
@@ -420,7 +420,7 @@ class BigQueryClient(object):
             configuration['encoding'] = encoding
 
         if schema:
-            configuration['schema'] = schema
+            configuration['schema'] = {'fields': schema}
 
         if source_format:
             configuration['sourceFormat'] = source_format


### PR DESCRIPTION
When loading data from a uri the job object was not being formed properly. The schema object was not nested within a fields key. I've added this nesting which is the same approach as used with the create table method. 
