### PR TITLE
Make InvalidSchemaType exception consistent

### DIFF
--- a/bigquery/errors.py
+++ b/bigquery/errors.py
@@ -9,7 +9,7 @@ class JobInsertException(Exception):
 class JobExecutingException(Exception):
     pass
 
-class InvalidSchemaType(Exception):
+class InvalidTypeException(Exception):
     def __init__(self, k, v):
         self.key = k
         self.value = v

--- a/bigquery/schema_builder.py
+++ b/bigquery/schema_builder.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import dateutil.parser
 
-from errors import InvalidSchemaType
+from errors import InvalidTypeException
 
 
 def default_timestamp_parser(s):
@@ -69,15 +69,15 @@ def describe_field(k, v, timestamp_parser=default_timestamp_parser):
 
     bq_type = bigquery_type(v, timestamp_parser=timestamp_parser)
     if not bq_type:
-        raise InvalidSchemaType(k, v)
+        raise InvalidTypeException(k, v)
 
     field = bq_schema_field(k, bq_type, mode)
     if bq_type == "record":
         try:
             field['fields'] = schema_from_record(v)
-        except InvalidSchemaType, e:
+        except InvalidTypeException, e:
             # recursively construct the key causing the error
-            raise InvalidSchemaType("%s.%s" % (k, e.key), e.value)
+            raise InvalidTypeException("%s.%s" % (k, e.key), e.value)
 
     return field
 

--- a/bigquery/tests/test_schema_builder.py
+++ b/bigquery/tests/test_schema_builder.py
@@ -6,7 +6,7 @@ from nose.tools import raises
 from bigquery.schema_builder import schema_from_record
 from bigquery.schema_builder import describe_field
 from bigquery.schema_builder import bigquery_type
-from bigquery.schema_builder import InvalidSchemaType
+from bigquery.schema_builder import InvalidTypeException
 
 
 class TestBigQueryTypes(unittest.TestCase):
@@ -97,7 +97,7 @@ class TestSchemaGenerator(unittest.TestCase):
 
         try:
             schema_from_record({"a": {"b": [{"c": None}]}})
-        except InvalidSchemaType, e:
+        except InvalidTypeException, e:
             key = e.key
             value = e.value
 


### PR DESCRIPTION
Here is a commit with the name you suggested.

Changed to InvalidSchemaType to InvalidTypeException, as suggested by @tylertreat in
https://github.com/tylertreat/BigQuery-Python/pull/23#discussion_r17335918
