### PR TITLE
Handle no datasets reply

### DIFF
--- a/bigquery/client.py
+++ b/bigquery/client.py
@@ -836,8 +836,8 @@ class BigQueryClient(object):
         ONE_MONTH = 2764800  # 32 days
 
         return start_time <= time <= end_time or \
-               time <= start_time <= time + ONE_MONTH or \
-               time <= end_time <= time + ONE_MONTH
+            time <= start_time <= time + ONE_MONTH or \
+            time <= end_time <= time + ONE_MONTH
 
     def _get_query_results(self, job_collection, project_id, job_id,
                            offset=None, limit=None):

--- a/bigquery/errors.py
+++ b/bigquery/errors.py
@@ -9,6 +9,7 @@ class JobInsertException(Exception):
 class JobExecutingException(Exception):
     pass
 
+
 class InvalidTypeException(Exception):
     def __init__(self, k, v):
         self.key = k

--- a/bigquery/tests/test_client.py
+++ b/bigquery/tests/test_client.py
@@ -1669,7 +1669,6 @@ class TestDeleteDataset(unittest.TestCase):
         self.mock_datasets.delete.return_value.execute. \
             assert_called_once_with()
 
-
     def test_delete_datasets_delete_contents_success(self):
         """Ensure that if deleting table succeeds, True is returned."""
 


### PR DESCRIPTION
BigQuery doesn't return a 'datasets' key when there are no datasets,
which results in an exception.  Fixed that problem.
