### PR TITLE
Parse totalRows to int.

### DIFF
--- a/bigquery/client.py
+++ b/bigquery/client.py
@@ -206,7 +206,7 @@ class BigQueryClient(object):
             job_collection, self.project_id, job_id, offset=0, limit=0)
 
         return (query_reply.get('jobComplete', False),
-                query_reply.get('totalRows', 0))
+                int(query_reply.get('totalRows', 0)))
 
     def get_query_rows(self, job_id, offset=None, limit=None):
         """Retrieve a list of rows from a query table by job id.

--- a/bigquery/tests/test_client.py
+++ b/bigquery/tests/test_client.py
@@ -396,7 +396,7 @@ class TestCheckJob(unittest.TestCase):
                     {'name': 'spider', 'type': 'STRING'}
                 ]
             },
-            'totalRows': 2
+            'totalRows': '2'
         }
 
         is_completed, total_rows = self.client.check_job(1)


### PR DESCRIPTION
It seems despite the docs[1](https://developers.google.com/bigquery/docs/reference/v2/jobs/getQueryResults) for getQueryResults stating that
totalRows returns an "unsigned long", in fact it returns a string.

Here's a snippet taken from the API explorer

```
"jobReference": {
  "projectId": "foo",
  "jobId": "job_RHAjGYT8d5P1JPGYL1mkZu4uK1X"
},
"totalRows": "1148",
```
