### PR TITLE
Fixed: Inconsistency for import_data_from_uris between documentation and actual code. 

### DIFF
--- a/bigquery/client.py
+++ b/bigquery/client.py
@@ -469,7 +469,7 @@ class BigQueryClient(object):
             configuration['encoding'] = encoding
 
         if schema:
-            configuration['schema'] = schema
+            configuration['schema'] = {'fields': schema}
 
         if source_format:
             configuration['sourceFormat'] = source_format

--- a/bigquery/tests/test_client.py
+++ b/bigquery/tests/test_client.py
@@ -578,7 +578,7 @@ class TestImportDataFromURIs(unittest.TestCase):
             "configuration": {
                 "load": {
                     "sourceUris": ["sourceuri"],
-                    "schema": ["schema"],
+                    "schema": {"fields": ["schema"]},
                     "destinationTable": {
                         "projectId": self.project_id,
                         "datasetId": self.dataset_id,
@@ -637,7 +637,7 @@ class TestImportDataFromURIs(unittest.TestCase):
             "configuration": {
                 "load": {
                     "sourceUris": ["sourceuri"],
-                    "schema": ["schema"],
+                    "schema": {"fields": ["schema"]},
                     "destinationTable": {
                         "projectId": self.project_id,
                         "datasetId": self.dataset_id,
@@ -732,7 +732,7 @@ class TestImportDataFromURIs(unittest.TestCase):
             "configuration": {
                 "load": {
                     "sourceUris": ["sourceuri"],
-                    "schema": ["schema"],
+                    "schema": {"fields": ["schema"]},
                     "destinationTable": {
                         "projectId": self.project_id,
                         "datasetId": self.dataset_id,


### PR DESCRIPTION
From documentation(https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.load.schema) where it shows that the schema should be a dictionary with 'fields' as  key and a list as value. 

README.md says that  we only need to pass a list of dictionaries to import_data_from_uris, where the json request generated is different from the google documentation.  

Personally I think the way done in README.me is clearer, any opinions? 

Cheers,
Paul