### PR TITLE
Passing the timestamp parser to describe field

### DIFF
--- a/bigquery/schema_builder.py
+++ b/bigquery/schema_builder.py
@@ -29,7 +29,8 @@ def schema_from_record(record, timestamp_parser=default_timestamp_parser):
     Returns:
         schema: list
     """
-    return [describe_field(k, v) for k, v in record.items()]
+    return [describe_field(k, v, timestamp_parser=timestamp_parser)
+            for k, v in record.items()]
 
 
 def describe_field(k, v, timestamp_parser=default_timestamp_parser):


### PR DESCRIPTION
The schama_from_record method takes a dictionary of the record and a timestamp parser.
The timestamp parser was not being passed to describe_field. The parameter was therefor useless.
This fix passes it to the describe field method.