### PR TITLE
Pass timestamp_parser to schema_from_record

### DIFF
--- a/bigquery/schema_builder.py
+++ b/bigquery/schema_builder.py
@@ -75,7 +75,7 @@ def describe_field(k, v, timestamp_parser=default_timestamp_parser):
     field = bq_schema_field(k, bq_type, mode)
     if bq_type == "record":
         try:
-            field['fields'] = schema_from_record(v)
+            field['fields'] = schema_from_record(v, timestamp_parser)
         except InvalidTypeException, e:
             # recursively construct the key causing the error
             raise InvalidTypeException("%s.%s" % (k, e.key), e.value)

--- a/bigquery/tests/test_schema_builder.py
+++ b/bigquery/tests/test_schema_builder.py
@@ -90,6 +90,33 @@ class TestSchemaGenerator(unittest.TestCase):
 
         self.assertItemsEqual(schema_from_record(record), schema)
 
+    def test_hierarchical_record_with_timestamps(self):
+        record = {"global": "2001-01-01", "user": {"local": "2001-01-01"}}
+
+        schema_with_ts = [
+            {"name": "global", "type": "timestamp", "mode": "nullable"},
+            {"name": "user", "type": "record", "mode": "nullable",
+                "fields": [{
+                    "name": "local",
+                    "type": "timestamp",
+                    "mode": "nullable"}]}]
+
+        schema_without_ts = [
+            {"name": "global", "type": "string", "mode": "nullable"},
+            {"name": "user", "type": "record", "mode": "nullable",
+                "fields": [{
+                    "name": "local",
+                    "type": "string",
+                    "mode": "nullable"}]}]
+
+        self.assertItemsEqual(
+            schema_from_record(record),
+            schema_with_ts)
+
+        self.assertItemsEqual(
+            schema_from_record(record, timestamp_parser=lambda x: False),
+            schema_without_ts)
+
     def test_repeated_field(self):
         record = {"ids": [1, 2, 3, 4, 5]}
         schema = [{"name": "ids", "type": "integer", "mode": "repeated"}]


### PR DESCRIPTION
Right now, if you pass a custom timestamp parser to `schema_from_record()`, it will be ignored when parsing inner `"record"` values.