### PR TITLE
Add expiration_time option for create_table

### DIFF
--- a/bigquery/client.py
+++ b/bigquery/client.py
@@ -384,13 +384,14 @@ class BigQueryClient(object):
 
         return table
 
-    def create_table(self, dataset, table, schema):
+    def create_table(self, dataset, table, schema, expiration_time=None):
         """Create a new table in the dataset.
 
         Args:
             dataset: the dataset to create the table in.
             table: the name of table to create.
             schema: table schema dict.
+            expiration_time: the expiry time in milliseconds since the epoch.
 
         Returns:
             bool indicating if the table was successfully created or not,
@@ -405,6 +406,9 @@ class BigQueryClient(object):
                 'datasetId': dataset
             }
         }
+
+        if expiration_time is not None:
+            body['expirationTime'] = expiration_time
 
         try:
             table = self.bigquery.tables().insert(

--- a/bigquery/tests/test_client.py
+++ b/bigquery/tests/test_client.py
@@ -1482,6 +1482,7 @@ class TestCreateTable(unittest.TestCase):
                 'tableId': self.table, 'projectId': self.project,
                 'datasetId': self.dataset}
         }
+        self.expiration_time = 1437513693000
 
     def test_table_create_failed(self):
         """Ensure that if creating the table fails, False is returned,
@@ -1532,6 +1533,26 @@ class TestCreateTable(unittest.TestCase):
 
         self.mock_tables.insert.assert_called_with(
             projectId=self.project, datasetId=self.dataset, body=self.body)
+
+        self.mock_tables.insert.return_value.execute.assert_called_with()
+
+    def test_table_create_body_with_expiration_time(self):
+        """Ensure that if expiration_time has specified,
+        it passed to the body."""
+
+        self.mock_tables.insert.return_value.execute.side_effect = [{
+            'status': 'foo'}, {'status': 'bar'}]
+
+        actual = self.client.create_table(self.dataset, self.table,
+                                          self.schema, self.expiration_time)
+
+        body = self.body.copy()
+        body.update({
+            'expirationTime': self.expiration_time
+        })
+
+        self.mock_tables.insert.assert_called_with(
+            projectId=self.project, datasetId=self.dataset, body=body)
 
         self.mock_tables.insert.return_value.execute.assert_called_with()
 

--- a/bigquery/tests/test_client.py
+++ b/bigquery/tests/test_client.py
@@ -1543,8 +1543,8 @@ class TestCreateTable(unittest.TestCase):
         self.mock_tables.insert.return_value.execute.side_effect = [{
             'status': 'foo'}, {'status': 'bar'}]
 
-        actual = self.client.create_table(self.dataset, self.table,
-                                          self.schema, self.expiration_time)
+        self.client.create_table(self.dataset, self.table,
+                                 self.schema, self.expiration_time)
 
         body = self.body.copy()
         body.update({


### PR DESCRIPTION
Table has `expirationTime` option. 
https://cloud.google.com/bigquery/docs/reference/v2/tables

So I added `expiration_time` option to `create_table` method.


Usage
```
>>> now = datetime.utcnow()
>>> now.strftime('%Y-%m-%d %H:%M:%S')
'2015-07-21 06:21:33'
>>> a_day_after = int(time.mktime(now.timetuple()))*1000 + 1000*60*60*24 # After 1 day
>>> a_day_after
1437513693000
>>> client = bigquery.get_client(...)
>>> client.create_table('test', 'expiry_test2', {}, expiration_time=a_day_after)
True
>>> client.get_table('test', 'expiry_test2')['expirationTime']
u'1437513693000'
```

Also we can check expiration time of table using bq command.
```
`--> bq show test.expiry_test2
Table vg-zucks-zgok:test.expiry_test2

   Last modified    Schema   Total Rows   Total Bytes     Expiration
 ----------------- -------- ------------ ------------- -----------------
  21 Jul 15:21:46            0            0             22 Jul 06:21:33
```