### PR TITLE
Remove PyOpenSSL dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 install:
+  - python setup.py develop
   - pip install tox
 script: tox -e $TOXENV
 notifications:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-google-api-python-client
-httplib2
-pyopenssl
-python-dateutil

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,4 +4,3 @@ mock==1.0.1
 coverage
 nose-exclude
 tox
--r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,11 @@ setup_args = dict(
     license='Apache',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=['google-api-python-client', 'pyopenssl', 'httplib2',
-                      'python-dateutil'],
+    install_requires=[
+        'google-api-python-client',
+        'httplib2',
+        'python-dateutil'
+    ],
     author='Tyler Treat',
     author_email='ttreat31@gmail.com',
     classifiers=[


### PR DESCRIPTION
PyOpenSSL is not used directly by this package, so we should let downstream packages decide if they want to use PyOpenSSL or PyCrypto.

As an example, the oauth2client package will, at runtime, check if PyOpenSSL is installed. If not, it will use PyCrypto.