### PR TITLE
Add support for JSON key authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ key = 'key.pem'
 client = get_client(project_id, service_account=service_account,
                     private_key_file=key, readonly=True)
 
+# JSON key provided by Google
+json_key = 'key.json'
+ 
+client = get_client(project_id, json_key_file=json_key, readonly=True)
+
 # Submit an async query.
 job_id, _results = client.query('SELECT * FROM dataset.my_table LIMIT 1000')
 

--- a/bigquery/tests/test_client.py
+++ b/bigquery/tests/test_client.py
@@ -135,6 +135,37 @@ class TestGetClient(unittest.TestCase):
         self.assertEquals(mock_bq, bq_client.bigquery)
         self.assertEquals(project_id, bq_client.project_id)
 
+    @mock.patch('bigquery.client._credentials')
+    @mock.patch('bigquery.client.build')
+    @mock.patch('__builtin__.open' if six.PY2 else 'builtins.open')
+    def test_initialize_json_key_file(self, mock_open, mock_build, mock_return_cred):
+        """Ensure that a BigQueryClient is initialized and returned with
+        read/write permissions using a JSON key file.
+        """
+        from bigquery.client import BIGQUERY_SCOPE
+        import json
+
+        mock_cred = mock.Mock()
+        mock_http = mock.Mock()
+        mock_cred.return_value.authorize.return_value = mock_http
+        mock_bq = mock.Mock()
+        mock_build.return_value = mock_bq
+        json_key_file = 'key.json'
+        json_key = {'client_email': 'mail', 'private_key': 'pkey'}
+        mock_open.return_value.__enter__.return_value.read.return_value = json.dumps(json_key)
+        project_id = 'project'
+        mock_return_cred.return_value = mock_cred
+
+        bq_client = client.get_client(project_id, json_key_file=json_key_file, readonly=False)
+
+        mock_open.assert_called_once_with(json_key_file, 'rb')
+        mock_return_cred.assert_called_once_with()
+        mock_cred.assert_called_once_with(json_key['client_email'], json_key['private_key'], scope=BIGQUERY_SCOPE)
+        self.assertTrue(mock_cred.return_value.authorize.called)
+        mock_build.assert_called_once_with('bigquery', 'v2', http=mock_http)
+        self.assertEquals(mock_bq, bq_client.bigquery)
+        self.assertEquals(project_id, bq_client.project_id)
+
 
 class TestQuery(unittest.TestCase):
 


### PR DESCRIPTION
I want to use JSON key for authorization because Google recommends it.

<img width="516" alt="2015-11-26 1 45 37" src="https://cloud.githubusercontent.com/assets/899217/11403302/6e1aa52c-93df-11e5-9837-5be87c9d7db9.png">
