### PR TITLE
Fix loading json for Python3

### DIFF
--- a/bigquery/client.py
+++ b/bigquery/client.py
@@ -82,8 +82,8 @@ def get_client(project_id, credentials=None, service_account=None,
             private_key = key_file.read()
 
     if json_key_file:
-        with open(json_key_file, 'rb') as key_file:
-            json_key = json.loads(key_file.read())
+        with open(json_key_file, 'r') as key_file:
+            json_key = json.load(key_file)
 
     if json_key:
         service_account = json_key['client_email']

--- a/bigquery/tests/test_client.py
+++ b/bigquery/tests/test_client.py
@@ -158,7 +158,7 @@ class TestGetClient(unittest.TestCase):
 
         bq_client = client.get_client(project_id, json_key_file=json_key_file, readonly=False)
 
-        mock_open.assert_called_once_with(json_key_file, 'rb')
+        mock_open.assert_called_once_with(json_key_file, 'r')
         mock_return_cred.assert_called_once_with()
         mock_cred.assert_called_once_with(json_key['client_email'], json_key['private_key'], scope=BIGQUERY_SCOPE)
         self.assertTrue(mock_cred.return_value.authorize.called)


### PR DESCRIPTION
json.loads() loads str but doesn't load byte in Python3.
It's a fix about this problem.