### PR TITLE
Specify oauth2client library version to 1.5.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup_args = dict(
     include_package_data=True,
     install_requires=[
         'google-api-python-client',
-        'httplib2',
+        'httplib2==1.5.2',
         'python-dateutil'
     ],
     author='Tyler Treat',


### PR DESCRIPTION
From oauth2client version 2.0.0, SignedJwtAssertionCredentials is removed, and this causes an import error. Therefore, I specify oauth2client library version to 1.5.2.

Please refer to the following link
https://github.com/google/oauth2client/releases/tag/v2.0.0
