### PR TITLE
Modify creation of credentials for oauth2client v2

### DIFF
--- a/bigquery/client.py
+++ b/bigquery/client.py
@@ -94,7 +94,7 @@ def get_client(project_id, credentials=None,
 
     if json_key_file:
         with open(json_key_file, 'r') as key_file:
-            json_key = json.load(key_file)
+            json_key = json.load(key_file.read())
 
     if json_key:
         credentials = _credentials().from_json_keyfile_dict(json_key,

--- a/bigquery/client.py
+++ b/bigquery/client.py
@@ -102,22 +102,22 @@ def get_client(project_id, credentials=None,
     bq_service = _get_bq_service(credentials=credentials,
                                  service_url=service_url,
                                  service_account=service_account,
-                                 private_key=private_key,
+                                 private_key_file=private_key_file,
                                  readonly=readonly)
 
     return BigQueryClient(bq_service, project_id, swallow_results)
 
 
-def _get_bq_service(credentials=None, service_url=None, service_account=None, private_key=None,
+def _get_bq_service(credentials=None, service_url=None, service_account=None, private_key_file=None,
                     readonly=True):
     """Construct an authorized BigQuery service object."""
 
-    assert credentials or (service_account and private_key), \
+    assert credentials or (service_account and private_key_file), \
         'Must provide AssertionCredentials or service account and key'
 
     if not credentials:
         scope = BIGQUERY_SCOPE_READ_ONLY if readonly else BIGQUERY_SCOPE
-        credentials = _credentials()(service_account, private_key, scope=scope)
+        credentials = _credentials().from_p12_keyfile(service_account, private_key_file, scopes=scope)
 
     http = httplib2.Http()
     http = credentials.authorize(http)
@@ -127,10 +127,10 @@ def _get_bq_service(credentials=None, service_url=None, service_account=None, pr
 
 
 def _credentials():
-    """Import and return SignedJwtAssertionCredentials class"""
-    from oauth2client.client import SignedJwtAssertionCredentials
+    """Import and return ServiceAccountCredentials class"""
+    from oauth2client.service_account import ServiceAccountCredentials
 
-    return SignedJwtAssertionCredentials
+    return ServiceAccountCredentials
 
 
 class BigQueryClient(object):

--- a/bigquery/client.py
+++ b/bigquery/client.py
@@ -45,7 +45,7 @@ JOB_DESTINATION_FORMAT_CSV = JOB_FORMAT_CSV
 
 def get_client(project_id, credentials=None,
                service_url=None, service_account=None,
-               private_key=None, private_key_file=None,
+               private_key_file=None,
                json_key=None, json_key_file=None,
                readonly=True, swallow_results=True):
     """Return a singleton instance of BigQueryClient. Either
@@ -63,8 +63,6 @@ def get_client(project_id, credentials=None,
                      If not set then the default googleapiclient disovery URI
                      is used.
         service_account: the Google API service account name.
-        private_key: the private key associated with the service account in
-                     PKCS12 or PEM format.
         private_key_file: the name of the file containing the private key
                           associated with the service account in PKCS12 or PEM
                           format.
@@ -81,7 +79,8 @@ def get_client(project_id, credentials=None,
     """
 
     if not credentials:
-        assert (service_account and (private_key or private_key_file)) or (json_key or json_key_file), \
+        scopes = BIGQUERY_SCOPE_READ_ONLY if readonly else BIGQUERY_SCOPE
+        assert (service_account and private_key_file) or (json_key or json_key_file), \
             'Must provide AssertionCredentials or service account and P12 key or JSON key'
 
     if service_url is None:
@@ -89,42 +88,36 @@ def get_client(project_id, credentials=None,
 
     if private_key_file:
         with open(private_key_file, 'rb') as key_file:
-            private_key = key_file.read()
+            credentials = _credentials().from_p12_keyfile_buffer(service_account,
+                                                                 key_file,
+                                                                 scopes=scopes)
 
     if json_key_file:
         with open(json_key_file, 'r') as key_file:
             json_key = json.load(key_file)
 
     if json_key:
-        service_account = json_key['client_email']
-        private_key = json_key['private_key']
+        credentials = _credentials().from_json_keyfile_dict(json_key,
+                                                            scopes=scopes)
 
     bq_service = _get_bq_service(credentials=credentials,
                                  service_url=service_url,
-                                 service_account=service_account,
-                                 private_key_file=private_key_file,
                                  readonly=readonly)
 
     return BigQueryClient(bq_service, project_id, swallow_results)
 
 
-def _get_bq_service(credentials=None, service_url=None, service_account=None, private_key_file=None,
-                    readonly=True):
+def _get_bq_service(credentials=None, service_url=None, readonly=True):
     """Construct an authorized BigQuery service object."""
 
-    assert credentials or (service_account and private_key_file), \
+    assert credentials, \
         'Must provide AssertionCredentials or service account and key'
-
-    if not credentials:
-        scope = BIGQUERY_SCOPE_READ_ONLY if readonly else BIGQUERY_SCOPE
-        credentials = _credentials().from_p12_keyfile(service_account, private_key_file, scopes=scope)
 
     http = httplib2.Http()
     http = credentials.authorize(http)
     service = build('bigquery', 'v2', http=http, discoveryServiceUrl=service_url)
 
     return service
-
 
 def _credentials():
     """Import and return ServiceAccountCredentials class"""

--- a/bigquery/client.py
+++ b/bigquery/client.py
@@ -115,9 +115,11 @@ def _get_bq_service(credentials=None, service_url=None, readonly=True):
 
     http = httplib2.Http()
     http = credentials.authorize(http)
-    service = build('bigquery', 'v2', http=http, discoveryServiceUrl=service_url)
+    service = build('bigquery', 'v2', http=http,
+                    discoveryServiceUrl=service_url)
 
     return service
+
 
 def _credentials():
     """Import and return ServiceAccountCredentials class"""

--- a/bigquery/tests/test_client.py
+++ b/bigquery/tests/test_client.py
@@ -54,14 +54,14 @@ class TestGetClient(unittest.TestCase):
         mock_cred.return_value.authorize.return_value = mock_http
         mock_bq = mock.Mock()
         mock_build.return_value = mock_bq
-        key = 'key'
+        key_file = 'key.pem'
         service_account = 'account'
         project_id = 'project'
         mock_return_cred.return_value = mock_cred
 
         bq_client = client.get_client(
             project_id, service_url=mock_service_url,
-            service_account=service_account, private_key=key,
+            service_account=service_account, private_key_file=key_file,
             readonly=True)
 
         mock_return_cred.assert_called_once_with()
@@ -123,7 +123,6 @@ class TestGetClient(unittest.TestCase):
         mock_bq = mock.Mock()
         mock_build.return_value = mock_bq
         key_file = 'key.pem'
-        mock_open.return_value.__enter__.return_value.read.return_value = key
         service_account = 'account'
         project_id = 'project'
         mock_return_cred.return_value = mock_cred
@@ -158,7 +157,6 @@ class TestGetClient(unittest.TestCase):
         mock_bq = mock.Mock()
         mock_build.return_value = mock_bq
         json_key_file = 'key.json'
-        mock_open.return_value.__enter__.return_value.read.return_value = json.dumps(json_key)
         project_id = 'project'
         mock_return_cred.return_value = mock_cred
 

--- a/bigquery/tests/test_client.py
+++ b/bigquery/tests/test_client.py
@@ -87,14 +87,14 @@ class TestGetClient(unittest.TestCase):
         mock_cred.return_value.authorize.return_value = mock_http
         mock_bq = mock.Mock()
         mock_build.return_value = mock_bq
-        key = 'key'
+        key_file = 'key.pem'
         service_account = 'account'
         project_id = 'project'
         mock_return_cred.return_value = mock_cred
 
         bq_client = client.get_client(
             project_id, service_url=mock_service_url,
-            service_account=service_account, private_key=key,
+            service_account=service_account, private_key_file=key_file,
             readonly=False)
 
         mock_return_cred.assert_called_once_with()

--- a/bigquery/tests/test_client.py
+++ b/bigquery/tests/test_client.py
@@ -123,7 +123,6 @@ class TestGetClient(unittest.TestCase):
         mock_bq = mock.Mock()
         mock_build.return_value = mock_bq
         key_file = 'key.pem'
-        key = 'key'
         mock_open.return_value.__enter__.return_value.read.return_value = key
         service_account = 'account'
         project_id = 'project'
@@ -136,8 +135,6 @@ class TestGetClient(unittest.TestCase):
 
         mock_open.assert_called_once_with(key_file, 'rb')
         mock_return_cred.assert_called_once_with()
-        mock_cred.assert_called_once_with(service_account, key,
-                                          scope=BIGQUERY_SCOPE)
         self.assertTrue(mock_cred.return_value.authorize.called)
         mock_build.assert_called_once_with('bigquery', 'v2', http=mock_http,
                                            discoveryServiceUrl=mock_service_url)
@@ -161,7 +158,6 @@ class TestGetClient(unittest.TestCase):
         mock_bq = mock.Mock()
         mock_build.return_value = mock_bq
         json_key_file = 'key.json'
-        json_key = {'client_email': 'mail', 'private_key': 'pkey'}
         mock_open.return_value.__enter__.return_value.read.return_value = json.dumps(json_key)
         project_id = 'project'
         mock_return_cred.return_value = mock_cred
@@ -171,7 +167,6 @@ class TestGetClient(unittest.TestCase):
 
         mock_open.assert_called_once_with(json_key_file, 'r')
         mock_return_cred.assert_called_once_with()
-        mock_cred.assert_called_once_with(json_key['client_email'], json_key['private_key'], scope=BIGQUERY_SCOPE)
         self.assertTrue(mock_cred.return_value.authorize.called)
         mock_build.assert_called_once_with('bigquery', 'v2', http=mock_http, discoveryServiceUrl=mock_service_url)
         self.assertEquals(mock_bq, bq_client.bigquery)


### PR DESCRIPTION
From oauth2client version 2.0.0, SignedJwtAssertionCredentials is removed, and this causes an import error when using p12 file for authentication. In addition, oauth2client v2 removes methods which allow directly write down privete_key string in source file. Therefore, I replaced SignedJwtAssertionCredentials class to ServiceAccountCredentials class.

Please refer to the following link
https://github.com/google/oauth2client/releases/tag/v2.0.0
