### PR TITLE
Read project_id from JSON key file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ client = get_client(project_id, service_account=service_account,
 # JSON key provided by Google
 json_key = 'key.json'
  
-client = get_client(project_id, json_key_file=json_key, readonly=True)
+client = get_client(json_key_file=json_key, readonly=True)
 
 # Submit an async query.
 job_id, _results = client.query('SELECT * FROM dataset.my_table LIMIT 1000')


### PR DESCRIPTION
A JSON key file provided by Google contains `project_id`. Now `project_id` argument of `get_client()` is optional and read from the JSON key file if `json_key` or `json_key_file` is provided. I believe this improve usability of `get_client()`. 

Before:

```python
import json
with open('credentials.json') as f:
    credentials = json.load(f)
client = bigquery.get_client(credentials['project_id'], json_key=credentials, readonly=False)
```

After:

```python
client = bigquery.get_client(json_key_file='credentials.json', readonly=False)
```

To implement this, I've reverted some codes changed by #91.