### PR TITLE
Add flatten boolean option

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,11 +294,6 @@ from bigquery import schema_from_record
 schema_from_record({"id":123, "posts": [{"id":123, "text": "tihs is a post"}], "username": "bob"})
 ```
 
-# Caveats
-
-BigQuery [flattens](https://developers.google.com/bigquery/docs/data?hl=ja#flatten) results with repeated records, so a result might actually map to multiple rows. This means that the row count may be larger than the actual number of results because BigQuery reports the number of unrolled rows but the returned results are rolled back up.
-
-
 # Contributing
 
 Requirements to commit here:

--- a/bigquery/client.py
+++ b/bigquery/client.py
@@ -1044,6 +1044,7 @@ class BigQueryClient(object):
             table=None,
             external_udf_uris=[],
             allow_large_results=None,
+            flatten=None,
             use_query_cache=None,
             priority=None,
             create_disposition=None,
@@ -1070,6 +1071,9 @@ class BigQueryClient(object):
             Storage and have .js extensions.
         allow_large_results : bool, optional
             Whether or not to allow large results
+        flatten : bool, optional
+            Whether or not to flatten nested and repeated fields
+            in query results
         use_query_cache : bool, optional
             Whether or not to use query cache
         priority : str, optional
@@ -1112,6 +1116,9 @@ class BigQueryClient(object):
 
         if allow_large_results is not None:
             configuration['allowLargeResults'] = allow_large_results
+
+        if flatten is not None:
+            configuration['flattenResults'] = flatten
 
         if maximum_billing_tier is not None:
             configuration['maximumBillingTier'] = maximum_billing_tier

--- a/bigquery/client.py
+++ b/bigquery/client.py
@@ -1071,9 +1071,6 @@ class BigQueryClient(object):
             Storage and have .js extensions.
         allow_large_results : bool, optional
             Whether or not to allow large results
-        flatten : bool, optional
-            Whether or not to flatten nested and repeated fields
-            in query results
         use_query_cache : bool, optional
             Whether or not to use query cache
         priority : str, optional
@@ -1091,6 +1088,9 @@ class BigQueryClient(object):
             unspecified, this will be set to your project default. For more
             information,
             see https://cloud.google.com/bigquery/pricing#high-compute
+        flatten : bool, optional
+            Whether or not to flatten nested and repeated fields
+            in query results
 
         Returns
         -------

--- a/bigquery/client.py
+++ b/bigquery/client.py
@@ -1044,13 +1044,13 @@ class BigQueryClient(object):
             table=None,
             external_udf_uris=[],
             allow_large_results=None,
-            flatten=None,
             use_query_cache=None,
             priority=None,
             create_disposition=None,
             write_disposition=None,
             use_legacy_sql=None,
-            maximum_billing_tier=None
+            maximum_billing_tier=None,
+            flatten=None
     ):
         """
         Write query result to table. If dataset or table is not provided,

--- a/bigquery/tests/test_client.py
+++ b/bigquery/tests/test_client.py
@@ -1121,6 +1121,7 @@ class TestWriteToTable(unittest.TestCase):
         self.external_udf_uris = ['gs://bucket/external_udf.js']
         self.use_query_cache = False
         self.priority = "INTERACTIVE"
+        self.flatten_results = False
         self.client = client.BigQueryClient(self.mock_api,
                                             self.project_id)
 
@@ -1144,6 +1145,7 @@ class TestWriteToTable(unittest.TestCase):
                     }],
                     "useQueryCache": self.use_query_cache,
                     "priority": self.priority,
+                    "flattenResults": self.flatten_results,
                 }
             }
         }
@@ -1154,6 +1156,7 @@ class TestWriteToTable(unittest.TestCase):
                                             self.table_id,
                                             external_udf_uris=self.external_udf_uris,
                                             use_query_cache=False,
+                                            flatten=False,
                                             priority=self.priority)
 
         self.mock_api.jobs().insert.assert_called_with(


### PR DESCRIPTION
Description
========

This allows the user to set the flatten boolean in the `write_to_table` method, so a table can be copied without flattening (by setting to `False`).

Review
=====
@tylertreat 