### PR TITLE
Add NullHandler to library logger

### DIFF
--- a/bigquery/client.py
+++ b/bigquery/client.py
@@ -47,7 +47,7 @@ JOB_DESTINATION_FORMAT_NEWLINE_DELIMITED_JSON = \
 JOB_DESTINATION_FORMAT_CSV = JOB_FORMAT_CSV
 
 logger = getLogger(__name__)
-logger.addHandler(logging.NullHandler())
+logger.addHandler(NullHandler())
 
 
 def get_client(project_id=None, credentials=None,

--- a/bigquery/client.py
+++ b/bigquery/client.py
@@ -1,6 +1,6 @@
 import calendar
 import json
-from logging import getLogger
+from logging import getLogger, NullHandler
 from collections import defaultdict
 from datetime import datetime, timedelta
 from hashlib import sha256
@@ -47,6 +47,7 @@ JOB_DESTINATION_FORMAT_NEWLINE_DELIMITED_JSON = \
 JOB_DESTINATION_FORMAT_CSV = JOB_FORMAT_CSV
 
 logger = getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 
 def get_client(project_id=None, credentials=None,

--- a/bigquery/query_builder.py
+++ b/bigquery/query_builder.py
@@ -1,6 +1,7 @@
-from logging import getLogger
+from logging import getLogger, NullHandler
 
 logger = getLogger(__name__)
+logger.addHandler(NullHandler())
 
 
 def render_query(dataset, tables, select=None, conditions=None,


### PR DESCRIPTION
If library is used without adding a logger, `BigQueryClient.push_rows` will throw a `No handlers could be found for logger` error.

This PR fixes that by adding a [logging.NullHandler](https://docs.python.org/2/library/logging.handlers.html#logging.NullHandler) to the loggers of `client` and `query_builder` as described [here](https://docs.python.org/2/howto/logging.html#library-config).