### PR TITLE
Add ability use legacy SQL or standard SQL when creating a view

### DIFF
--- a/bigquery/client.py
+++ b/bigquery/client.py
@@ -691,6 +691,9 @@ class BigQueryClient(object):
             The name of the view to create
         query : dict
             A query that BigQuery executes when the view is referenced.
+        use_legacy_sql : bool, optional
+            If False, the query will use BigQuery's standard SQL
+            (https://cloud.google.com/bigquery/sql-reference/)
 
         Returns
         -------

--- a/bigquery/client.py
+++ b/bigquery/client.py
@@ -680,7 +680,7 @@ class BigQueryClient(object):
             else:
                 return {}
 
-    def create_view(self, dataset, view, query):
+    def create_view(self, dataset, view, query, use_legacy_sql=None):
         """Create a new view in the dataset.
 
         Parameters
@@ -709,6 +709,9 @@ class BigQueryClient(object):
                 'query': query
             }
         }
+
+        if use_legacy_sql is not None:
+            body['view']['useLegacySql'] = use_legacy_sql
 
         try:
             view = self.bigquery.tables().insert(


### PR DESCRIPTION
Nothing fancy, follows the same convention as the other methods that allow for signifying whether legacy SQL or standard SQL is used.