### PR TITLE
Add support for long in schema_builder

### DIFF
--- a/bigquery/schema_builder.py
+++ b/bigquery/schema_builder.py
@@ -126,7 +126,7 @@ def bigquery_type(o, timestamp_parser=default_timestamp_parser):
     """
 
     t = type(o)
-    if isinstance(t, six.integertype):
+    if isinstance(t, six.integer_types):
         return "integer"
     elif (t == six.binary_type and six.PY2) or t == six.text_type:
         if timestamp_parser and timestamp_parser(o):

--- a/bigquery/schema_builder.py
+++ b/bigquery/schema_builder.py
@@ -126,7 +126,7 @@ def bigquery_type(o, timestamp_parser=default_timestamp_parser):
     """
 
     t = type(o)
-    if t == int:
+    if t == int or t == long:
         return "integer"
     elif (t == six.binary_type and six.PY2) or t == six.text_type:
         if timestamp_parser and timestamp_parser(o):

--- a/bigquery/schema_builder.py
+++ b/bigquery/schema_builder.py
@@ -126,7 +126,7 @@ def bigquery_type(o, timestamp_parser=default_timestamp_parser):
     """
 
     t = type(o)
-    if isinstance(t, six.integer_types):
+    if t in six.integer_types:
         return "integer"
     elif (t == six.binary_type and six.PY2) or t == six.text_type:
         if timestamp_parser and timestamp_parser(o):

--- a/bigquery/schema_builder.py
+++ b/bigquery/schema_builder.py
@@ -126,7 +126,7 @@ def bigquery_type(o, timestamp_parser=default_timestamp_parser):
     """
 
     t = type(o)
-    if t == int or t == long:
+    if isinstance(t, six.integertype):
         return "integer"
     elif (t == six.binary_type and six.PY2) or t == six.text_type:
         if timestamp_parser and timestamp_parser(o):


### PR DESCRIPTION
Some of the data that I have been dealing with had fields that were getting converted to long datatypes by Python, which were getting ignored/throwing an error when attempting to build a schema. This should now return "integer" when a long is passed to the function