### PR TITLE
Fix client.patch_table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ notifications:
   email: false
 env:
   - TOXENV=py27
-  - TOXENV=py34
+  - TOXENV=py35
+  - TOXENV=py36
   - TOXENV=nightly
   - TOXENV=pypy

--- a/bigquery/client.py
+++ b/bigquery/client.py
@@ -735,17 +735,13 @@ class BigQueryClient(object):
 
         body = {
             'schema': {'fields': schema},
-            'tableReference': {
-                'tableId': table,
-                'projectId': project_id,
-                'datasetId': dataset
-            }
         }
 
         try:
             result = self.bigquery.tables().patch(
                 projectId=project_id,
                 datasetId=dataset,
+                tableId=table,
                 body=body
             ).execute(num_retries=self.num_retries)
             if self.swallow_results:

--- a/bigquery/tests/test_client.py
+++ b/bigquery/tests/test_client.py
@@ -1913,9 +1913,6 @@ class TestPatchTable(unittest.TestCase):
         self.client = client.BigQueryClient(self.mock_bq_service, self.project)
         self.body = {
             'schema': {'fields': self.schema},
-            'tableReference': {
-                'tableId': self.table, 'projectId': self.project,
-                'datasetId': self.dataset}
         }
         self.expiration_time = 1437513693000
 
@@ -1941,7 +1938,8 @@ class TestPatchTable(unittest.TestCase):
         self.client.swallow_results = True
 
         self.mock_tables.patch.assert_called_with(
-            projectId=self.project, datasetId=self.dataset, body=self.body)
+            projectId=self.project, datasetId=self.dataset,
+            tableId=self.table, body=self.body)
 
         self.mock_tables.patch.return_value.execute. \
             assert_called_with(num_retries=0)
@@ -1968,7 +1966,8 @@ class TestPatchTable(unittest.TestCase):
         self.client.swallow_results = True
 
         self.mock_tables.patch.assert_called_with(
-            projectId=self.project, datasetId=self.dataset, body=self.body)
+            projectId=self.project, datasetId=self.dataset,
+            tableId=self.table, body=self.body)
 
         self.mock_tables.patch.return_value.execute. \
             assert_called_with(num_retries=0)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py33, py34, nightly, pypy
+envlist = py27, py35, py36, nightly, pypy
 
 [testenv]
 commands = nosetests --logging-level=ERROR -a slow --with-coverage --cover-package=bigquery


### PR DESCRIPTION
tableId is a required argument of the patch method. Also, there's no
need to pass a tableReference in the body.

Signed-off-by: Yves Bastide <yves@botify.com>